### PR TITLE
Feature/MED-53: Add virtiofs filesystem in emby-test

### DIFF
--- a/test/main.tf
+++ b/test/main.tf
@@ -69,4 +69,48 @@ resource "libvirt_domain" "emby" {
     target_port = 0
   }
 
+  xml {
+    xslt = <<EOF
+  <?xml version="1.0" ?>
+  <xsl:stylesheet version="1.0"
+                  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output omit-xml-declaration="yes" indent="yes" />
+    <xsl:template match="node()|@*">
+       <xsl:copy>
+         <xsl:apply-templates select="node()|@*"/>
+       </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="/domain">
+      <xsl:copy>
+        <xsl:apply-templates select="@*"/>
+        <xsl:apply-templates select="node()"/>
+        <memoryBacking>
+          <access mode='shared'/>
+        </memoryBacking>
+      </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="/domain/devices">
+      <xsl:copy>
+        <xsl:apply-templates select="@*"/>
+        <xsl:apply-templates select="node()"/>
+        <filesystem type='mount' accessmode='passthrough'>
+          <driver type='virtiofs'/>
+          <binary path='/usr/lib/qemu/virtiofsd'/>
+          <source dir='/zpools/data_disk/emby-test'/>
+          <target dir='emby-data'/>
+          <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
+        </filesystem>
+      </xsl:copy>
+    </xsl:template>
+  </xsl:stylesheet>
+  EOF
+  }
+
+  lifecycle {
+    ignore_changes = [xml, filesystem]
+  }
+
+
 }


### PR DESCRIPTION
This allows for emby-test to load a filesystem as virtiofs from the host (vmhost01) and its external disk. 
The provider for libvirt does not allow for this so i needed to do direct xml surgery 

The line in 
```
          <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
```
is so that the PCI device is not added before the networks as this is breaking the netplan setup in the cloud VM.

This will allow the code changes in https://github.com/michnmi/ansible_internal/pull/251 to work. 

It is needed. The next step will be to allow this for production as well once the external disk is available. 
